### PR TITLE
Proposal Allow mapping to return function when not wrapped with `stub`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -57,7 +57,7 @@ function getNextVal(searchVal, mapping) {
     value = (mapping.find(keyVal => deepEqual(keyVal[0], searchVal)) || [])[1]
   }
 
-  if (typeof value === 'function') {
+  if (typeof value === 'function' && value._isReduxSagaTestEngineStub) {
     return value()
   }
   return value
@@ -84,9 +84,13 @@ function stringifyVal(val) {
 const stub = (genFunc, ...args) => {
   if (isGeneratorFunction(genFunc)) {
     const gen = genFunc(...args)
-    return () => gen.next().value
+    const stubFunc = () => gen.next().value
+    stubFunc._isReduxSagaTestEngineStub = true
+    return stubFunc
   } else {
-    return () => genFunc(...args)
+    const stubFunc = () => genFunc(...args)
+    stubFunc._isReduxSagaTestEngineStub = true
+    return stubFunc
   }
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -153,13 +153,15 @@ test('getNextVal', t => {
     'Handled deeply-nested objects in arrays part 2'
   )
 
-  // Nested Array with simple stubs
-  t.is(2, getNextVal(1, [[1, () => 2]]))
-  t.is(2, getNextVal(1, [[1, () => 2], [1, () => 3]]))
-  t.is(4, getNextVal(3, [[1, () => 2], [3, () => 4]]))
+  const testFunction = () => 1
+
+  // Nested Array with returned functions
+  t.is(testFunction, getNextVal(1, [[1, testFunction]]))
+  t.is(testFunction, getNextVal(1, [[1, testFunction], [1, () => 3]]))
+  t.is(testFunction, getNextVal(3, [[1, () => 2], [3, testFunction]]))
   t.is(
-    'val',
-    getNextVal({ a: { b: { c: 1 } } }, [[{ a: { b: { c: 1 } } }, () => 'val']]),
+    testFunction,
+    getNextVal({ a: { b: { c: 1 } } }, [[{ a: { b: { c: 1 } } }, testFunction]]),
     'Handled deeply-nested objects in arrays with simple stubs'
   )
   t.is(
@@ -197,11 +199,11 @@ test('getNextVal', t => {
   )
 
   // Map with simple stubs
-  t.is(2, getNextVal(1, new Map([[1, () => 2]])))
-  t.is(4, getNextVal(3, new Map([[1, () => 2], [3, () => 4]])))
+  t.is(testFunction, getNextVal(1, new Map([[1, testFunction]])))
+  t.is(testFunction, getNextVal(3, new Map([[1, () => 2], [3, testFunction]])))
   t.is(
-    'val',
-    getNextVal({ a: { b: { c: 1 } } }, new Map([[{ a: { b: { c: 1 } } }, () => 'val']])),
+    testFunction,
+    getNextVal({ a: { b: { c: 1 } } }, new Map([[{ a: { b: { c: 1 } } }, testFunction]])),
     'Handled deeply-nested objects in Map with simple stubs'
   )
   t.is(


### PR DESCRIPTION
https://github.com/timbuckley/redux-saga-test-engine/commit/b8d0a95fe25fa960f109b92dde7cc47e02c55a53 introduced a breaking change where mappings that return functions will now return the result of those functions.

It appears the intent was only to support dynamic return values using `stub`.

This PR preserves the behavior of `stub` but eliminates calling functions that are specified as return values in mappings.

Note, this _is_ a breaking change to 2.1.0 and 3.0.0, but it restores broken behavior from 2.0.3 which I believe was more correct.  Would love feedback!